### PR TITLE
script to make a latex author list from a CSV file. 

### DIFF
--- a/authors.py
+++ b/authors.py
@@ -1,0 +1,84 @@
+import os,optparse,csv
+
+if __name__ == "__main__":
+
+    parser = optparse.OptionParser(usage='usage: %prog <format>', version='%prog 1.0')
+    parser.add_option(       '--datafile' , type='string'       , default='data/authorlist.csv' , help='use this alternative input file (expect CSV)')
+    (options, args) = parser.parse_args()
+
+    if len(args)<1:
+        print("Need to give the format as argument. Supported formats are:\n")
+        print("POSlatex [default]")
+        exit(1)
+
+    outformat = args[0]
+
+    data = []
+    with open(options.datafile, newline='') as csvfile:
+        reader = csv.reader(csvfile, delimiter='|')
+        for row in reader:
+            if len(row)<1 or row[0].startswith("#"):
+                continue
+            key = (row[0],row[1],row[2])
+            data.append([key, row[3:]])
+
+
+    # sort in alphabetical order of second name
+    sorted_data = sorted(data, key=lambda x: x[0][2], reverse=False)
+
+    affiliations = []
+    aff_with_keys = {}
+    charkey = ord('a')
+    for author in sorted_data:
+        auth_institutes = author[1][1:]
+        for i in auth_institutes:
+            if i.strip() not in affiliations:
+                affiliations.append(i.strip())
+                aff_with_keys[i.strip()]=chr(charkey)
+                charkey = charkey + 1
+
+    if outformat=="POSlatex":
+        # formats
+        auth_fmt = "\\author[{instkeys}]{{{author_fullname}}}"
+        affiliation_fmt = "\\affiliation[{instkey}]{{{inst_fullname}}}"
+
+        outfile_name = "cygno_authors_pos.tex"
+        fout = open(outfile_name,"w")
+        
+        authors = []
+        fout.write("% CYGNO blessed authors. Add undergraduate students if their thesis work is contained in this paper\n")
+        for author in sorted_data:
+            auth_fullname = author[0]
+            firsts  = auth_fullname[0].strip().split(" ")
+            middles = auth_fullname[1].strip().split(" ")
+            lasts   = auth_fullname[2].strip().split(" ")
+            authname = ".".join([first[0] for first in firsts]) + "." + ".".join([middle[0] for middle in middles if len(middle)])
+            if len(middles[-1]):
+                authname = authname + "."
+            authname = authname + "~" + " ".join(lasts)
+            auth_inst_keys = [aff_with_keys[i.strip()] for i in author[1][1:]]
+
+            formatted_author = auth_fmt.format(instkeys=','.join(auth_inst_keys),author_fullname=authname) + "\n"
+            fout.write(formatted_author)
+            authors.append(formatted_author)
+
+        fout.write("\n\n%CYGNO institutions\n")
+        affiliations = []
+        for inst,k in aff_with_keys.items():
+            formatted_inst = affiliation_fmt.format(instkey=k,inst_fullname=inst) + "\n"
+            fout.write(formatted_inst)
+            affiliations.append(formatted_inst)
+            
+        fout.close()
+
+        print("Output written in ",outfile_name,". Please check contents carefully.")
+        
+        # print ("===> AUTHORS <===")
+        # print (authors)
+        
+        # print ("===> INSTITUTES <===")
+        # print (affiliations)
+    else:
+        print ("Format ",outformat," not yet implemented. Nothing written. ")
+    
+            

--- a/data/authorlist.csv
+++ b/data/authorlist.csv
@@ -1,0 +1,52 @@
+# ========================================================================================
+# Format is:
+# First Name | Middle Name | Last Name   | e-mail | Institution 1 | Institution 2 ...
+# ========================================================================================
+Fernando Domingues |       | Amaro       | famaro@uc.pt | Department of Physics, University of Coimbra, 3004-516 Coimbra, Portugal 
+Elisabetta         |       | Baracchini  | elisabetta.baracchini@gssi.it | Gran Sasso Science Institute, 67100, L'Aquila, Italy | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali del Gran Sasso, 67100, Assergi, Italy
+Luigi              |       | Benussi     | luigi.benussi@lnf.infn.it  | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Stefano            |       | Bianco      | stefano.bianco@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Cesidio            |       | Capoccia    | cesidio.capoccia@lnf.infn.it  | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Michele            |       | Caponero    | caponero@frascati.enea.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy | ENEA Centro Ricerche Frascati, 00044, Frascati, Italy 
+Danilo             | Santos | Cardoso | dsantoscardoso@outlook.com | Centro Brasileiro de Pesquisas Físicas, Rio de Janeiro 22290-180, RJ, Brazil
+Gianluca           |        | Cavoto  | gianluca.cavoto@roma1.infn.it | Dipartimento di Fisica, Universit\`a La Sapienza di Roma, 00185, Roma, Italy | Istituto Nazionale di Fisica Nucleare, Sezione di Roma, 00185, Rome, Italy 
+Andr\'e            |        | Cortez | andre.f.cortez@gmail.com | Gran Sasso Science Institute, 67100, L'Aquila, Italy | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali del Gran Sasso, 67100, Assergi, Italy
+Igor               | Abritta | Costa | igorabritta@gmail.com | Universidade Federal de Juiz de Fora, Faculdade de Engenharia, 36036-900, Juiz de Fora, MG, Brasil
+Emiliano           |        | Dan\'e | Emiliano.Dane@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Giorgio            |        | Dho    | giorgio.dho@gssi .it | Gran Sasso Science Institute, 67100, L'Aquila, Italy | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali del Gran Sasso, 67100, Assergi, Italy
+Flaminia           |        | Di Giambattista | flaminia.digiambattista@gssi .it | Gran Sasso Science Institute, 67100, L'Aquila, Italy | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali del Gran Sasso, 67100, Assergi, Italy
+Emanuele           |        | Di Marco  | emanuele.dimarco@roma1.infn.it | Istituto Nazionale di Fisica Nucleare, Sezione di Roma, 00185, Rome, Italy
+Giulia             |        | D'Imperio | giulia.dimperio@roma1.infn.it  | Istituto Nazionale di Fisica Nucleare, Sezione di Roma, 00185, Rome, Italy
+Francesco          |        | Iacoangeli | Francesco.iacoangeli@roma1.infn.it | Istituto Nazionale di Fisica Nucleare, Sezione di Roma, 00185, Rome, Italy
+Herman             | Pessoa | Lima J\’unior | hlima@cbpf.br | Centro Brasileiro de Pesquisas Físicas, Rio de Janeiro 22290-180, RJ, Brazil
+Amaro              | da Silva | Lopes J\’unior | silva.lopes@ufjf.edu.br | Universidade Federal de Juiz de Fora, Faculdade de Engenharia, 36036-900, Juiz de Fora, MG, Brasil
+Giovanni           |        | Maccarrone | giovanni.maccarrone@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Rui Daniel         | Passos | Mano | RDPMano@uc.pt | LIBPhys, Department of Physics, University of Coimbra, 3004-516 Coimbra, Portugal
+Michela            |        | Marafini | Michela.Marafini@roma1.infn.it  | Museo Storico della Fisica e Centro Studi e Ricerche ``Enrico Fermi'', Piazza del Viminale 1, 00184, Roma, Italy
+Robert             | Renz   | Marcelo Gregorio | robert.gregorio@sheffield.ac.uk  | Department of Physics and Astronomy, University of Sheffield, Sheffield, S3 7RH, UK
+David              |        | Marques | david.marques@gssi.it | Gran Sasso Science Institute, 67100, L'Aquila, Italy | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali del Gran Sasso, 67100, Assergi, Italy
+Giovanni           |        | Mazzitelli | giovanni.mazzitelli@lnf.roma1.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Alasdair           | Gregor | McLean | ali.mclean@sheffield.ac.uk | Department of Physics and Astronomy, University of Sheffield, Sheffield, S3 7RH, UK
+Andrea             |        | Messina | andrea.messina@uniroma1.it | Dipartimento di Fisica, Universit\`a La Sapienza di Roma, 00185, Roma, Italy | Istituto Nazionale di Fisica Nucleare, Sezione di Roma, 00185, Rome, Italy 
+Cristina Maria     | Bernardes | Monteiro | cristinam@uc.pt | LIBPhys, Department of Physics, University of Coimbra, 3004-516 Coimbra, Portugal
+Rafael             | Antunes | Nobrega | rafael.nobrega@ufjf.edu.br | Universidade Federal de Juiz de Fora, Faculdade de Engenharia, 36036-900, Juiz de Fora, MG, Brasil
+Igor               | Fonseca | Pains | igor.pains@ufjf.edu.br | Universidade Federal de Juiz de Fora, Faculdade de Engenharia, 36036-900, Juiz de Fora, MG, Brasil
+Emiliano           |         | Paoletti | Emiliano.Paoletti@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Luciano            |         | Passamonti | luciano.passamonti@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Sandro             |         | Pelosi | Alessandro.Pelosi@roma1.infn.it  | Istituto Nazionale di Fisica Nucleare, Sezione di Roma, 00185, Rome, Italy
+Fabrizio           |         | Petrucci | fabrizio.petrucci@uniroma3.it | Dipartimento di Matematica e Fisica, Universit\`a Roma TRE, 00146, Roma, Italy
+Stefano            |         | Piacentini | stefano.piacentini@uniroma1.it | Dipartimento di Fisica, Universit\`a La Sapienza di Roma, 00185, Roma, Italy | Istituto Nazionale di Fisica Nucleare, Sezione di Roma, 00185, Rome, Italy 
+Davide             |         | Piccolo | davide.piccolo@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Daniele            |         | Pierluigi | Daniele.Pierluigi@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Davide             |         | Pinci | davide.pinci@roma1.infn.it | Istituto Nazionale di Fisica Nucleare, Sezione di Roma, 00185, Rome, Italy
+Atul               |         | Prajapati | atul.prajapati@gssi.it | Gran Sasso Science Institute, 67100, L'Aquila, Italy | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali del Gran Sasso, 67100, Assergi, Italy
+Francesco          |         | Renga | francesco.renga@roma1.infn.it | Istituto Nazionale di Fisica Nucleare, Sezione di Roma, 00185, Rome, Italy
+Rita               | Joana da Cruz | Roque | ritaroque@fis.uc.pt | LIBPhys, Department of Physics, University of Coimbra, 3004-516 Coimbra, Portugal
+Filippo            |         | Rosatelli | filippo.rosatelli@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Andrea             |         | Russo | arusso@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Joaquim            | Marques Ferreira dos | Santos | jmf@uc.pt | LIBPhys, Department of Physics, University of Coimbra, 3004-516 Coimbra, Portugal
+Giovanna           |         | Saviano | giovanna.saviano@cern.ch | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy | Dipartimento di Ingegneria Chimica, Materiali e Ambiente, Sapienza Universit\`a di Roma, 00185, Roma, Italy
+Neil               |         | Spooner | n.spooner@sheffield.ac.uk | Department of Physics and Astronomy, University of Sheffield, Sheffield, S3 7RH, UK
+Roberto            |         | Tesauro | Roberto.Tesauro@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Sandro             |         | Tomassini | sandro.tomassini@lnf.infn.it | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali  di Frascati,  00044, Frascati, Italy
+Samuele            |         | Torelli | samuele.torelli@gssi.it | Gran Sasso Science Institute, 67100, L'Aquila, Italy | Istituto Nazionale di Fisica Nucleare, Laboratori Nazionali del Gran Sasso, 67100, Assergi, Italy


### PR DESCRIPTION
Only one output format is implemented. 
The CSV file also contains the e-mail, but at the moment for the POSlatex format is not displayed. 

Usage:

`python authors.py POSlatex --datafile data/authorlist.csv`

make a file with entries like:

`\author[a]{F.D.~Amaro}`
`\affiliation[a]{Department of Physics, University of Coimbra, 3004-516 Coimbra, Portugal}`

sorted in alphabetical order of the last name. 
The affiliations are sorted by the order of the authors second name. Middle names are abbreviated. 
